### PR TITLE
Tune codecov threshold before alpha

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -9,8 +9,14 @@ coverage:
   status:
     project:
       default:
-        # add a threshold
-        threshold: null
+        # TODO: change once in alpha (auto)
+        target: 50%
+        threshold: 0.05%
+    patch:
+      default:
+        # TODO: change once in alpha (80%)
+        target: 50%
+        threshold: 0.05%
 
 comment:
   layout: "header, diff, changes, uncovered, tree"

--- a/codecov.yml
+++ b/codecov.yml
@@ -11,12 +11,12 @@ coverage:
       default:
         # TODO: change once in alpha (auto)
         target: 50%
-        threshold: 0.05%
+        threshold: 1%
     patch:
       default:
         # TODO: change once in alpha (80%)
         target: 50%
-        threshold: 0.05%
+        threshold: 1%
 
 comment:
   layout: "header, diff, changes, uncovered, tree"


### PR DESCRIPTION
Because the thresholds are never met, it is better to have less stringent thresholds til we have the current code developed and then increase the coverage if necessary. This is useful because some of the classes that we are porting are diretly deprecated and we don't want to invest time on porting the tests for the small refactoring that we are doing.
